### PR TITLE
Changed mkdir() to makedirs()

### DIFF
--- a/agents/agents.py
+++ b/agents/agents.py
@@ -100,7 +100,7 @@ class DQNAgentBase:
             log_dir = Path(
                 os.path.join("runs", time.strftime("%d_%m_%Y-%H_%M_%S"))
             )
-            os.mkdir(log_dir)
+            os.makedirs(log_dir)
         logging.info(f"{ __name__}: Saving logs in {log_dir}.")
         with open(os.path.join(log_dir, "logs.csv"), "a+", newline="") as file:
             writer = csv.writer(file)


### PR DESCRIPTION
* This will no longer throw error if ```runs``` folder doesn't exist.